### PR TITLE
Add Archimate palette with drag-and-drop

### DIFF
--- a/frontend/components/DiagramEditor.tsx
+++ b/frontend/components/DiagramEditor.tsx
@@ -1,46 +1,82 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useRef } from 'react';
+import { ARCHIMATE_ELEMENTS, ElementType } from './archimateElements';
 
 interface Node {
   id: number;
   x: number;
   y: number;
-  label: string;
+  type: ElementType;
 }
 
 export default function DiagramEditor() {
   const [nodes, setNodes] = useState<Node[]>([]);
   const [dragId, setDragId] = useState<number | null>(null);
-
-  const addNode = () => {
-    setNodes([...nodes, { id: Date.now(), x: 50, y: 50, label: 'Elemento' }]);
-  };
+  const [dragType, setDragType] = useState<ElementType | null>(null);
+  const canvasRef = useRef<HTMLDivElement>(null);
 
   const startDrag = (id: number) => setDragId(id);
   const stopDrag = () => setDragId(null);
 
   const onMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
-    if (dragId === null) return;
-    setNodes(nodes.map(n => n.id === dragId ? { ...n, x: e.nativeEvent.offsetX, y: e.nativeEvent.offsetY } : n));
+    if (dragId === null || !canvasRef.current) return;
+    const rect = canvasRef.current.getBoundingClientRect();
+    setNodes(nodes.map(n => n.id === dragId ? { ...n, x: e.clientX - rect.left, y: e.clientY - rect.top } : n));
   };
 
+  const handlePaletteDragStart = (el: ElementType) => (e: React.DragEvent<HTMLDivElement>) => {
+    setDragType(el);
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    if (!dragType || !canvasRef.current) return;
+    const rect = canvasRef.current.getBoundingClientRect();
+    setNodes([
+      ...nodes,
+      { id: Date.now(), x: e.clientX - rect.left, y: e.clientY - rect.top, type: dragType }
+    ]);
+    setDragType(null);
+  };
+
+  const allowDrop = (e: React.DragEvent<HTMLDivElement>) => e.preventDefault();
+
   return (
-    <div className="flex flex-1" onMouseMove={onMouseMove} onMouseUp={stopDrag}>
-      <div className="w-40 bg-gray-100 border-r p-2 space-y-2">
-        <button className="w-full bg-blue-500 text-white p-1 rounded" onClick={addNode}>
-          Adicionar Elemento
-        </button>
-      </div>
-      <div className="flex-1 relative bg-white">
+    <div className="flex flex-1 overflow-hidden" onMouseMove={onMouseMove} onMouseUp={stopDrag}>
+      <div
+        ref={canvasRef}
+        className="flex-1 relative bg-white"
+        onDrop={handleDrop}
+        onDragOver={allowDrop}
+      >
         {nodes.map(node => (
           <div
             key={node.id}
-            className="absolute px-2 py-1 bg-green-200 border rounded cursor-move"
+            className="absolute cursor-move"
             style={{ left: node.x, top: node.y }}
             onMouseDown={() => startDrag(node.id)}
           >
-            {node.label}
+            <div
+              className="relative px-2 py-1 border rounded text-sm shadow"
+              style={{ backgroundColor: node.type.color }}
+            >
+              <span className="absolute top-0 right-0 text-xs">{node.type.icon}</span>
+              {node.type.name}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="w-48 bg-gray-100 border-l p-2 overflow-y-auto space-y-2">
+        {ARCHIMATE_ELEMENTS.map(el => (
+          <div
+            key={el.name}
+            draggable
+            onDragStart={handlePaletteDragStart(el)}
+            className="p-1 border rounded bg-white text-xs flex items-center cursor-grab"
+          >
+            <span className="mr-1">{el.icon}</span>
+            {el.name}
           </div>
         ))}
       </div>

--- a/frontend/components/archimateElements.ts
+++ b/frontend/components/archimateElements.ts
@@ -1,0 +1,82 @@
+export interface ElementType {
+  name: string;
+  color: string;
+  icon: string;
+}
+
+export const ARCHIMATE_ELEMENTS: ElementType[] = [
+  // Strategy layer
+  { name: "Capability", color: "#E0D3F8", icon: "📈" },
+  { name: "Course of Action", color: "#E0D3F8", icon: "🏹" },
+  { name: "Resource", color: "#E0D3F8", icon: "🧰" },
+  { name: "Value Stream", color: "#E0D3F8", icon: "🔄" },
+
+  // Business layer
+  { name: "Business Actor", color: "#FFF2CC", icon: "👤" },
+  { name: "Business Role", color: "#FFF2CC", icon: "🎭" },
+  { name: "Business Collaboration", color: "#FFF2CC", icon: "🤝" },
+  { name: "Business Interface", color: "#FFF2CC", icon: "🔌" },
+  { name: "Business Process", color: "#FFF2CC", icon: "📝" },
+  { name: "Business Function", color: "#FFF2CC", icon: "⚙" },
+  { name: "Business Interaction", color: "#FFF2CC", icon: "🔀" },
+  { name: "Business Service", color: "#FFF2CC", icon: "💼" },
+  { name: "Business Event", color: "#FFF2CC", icon: "📅" },
+  { name: "Business Object", color: "#FFF2CC", icon: "📦" },
+  { name: "Contract", color: "#FFF2CC", icon: "📜" },
+  { name: "Product", color: "#FFF2CC", icon: "📦" },
+
+  // Application layer
+  { name: "Application Component", color: "#DAE8FC", icon: "🧩" },
+  { name: "Application Collaboration", color: "#DAE8FC", icon: "🤝" },
+  { name: "Application Interface", color: "#DAE8FC", icon: "🔌" },
+  { name: "Application Function", color: "#DAE8FC", icon: "⚙" },
+  { name: "Application Service", color: "#DAE8FC", icon: "💻" },
+  { name: "Application Process", color: "#DAE8FC", icon: "📝" },
+  { name: "Application Interaction", color: "#DAE8FC", icon: "🔀" },
+  { name: "Application Event", color: "#DAE8FC", icon: "📅" },
+  { name: "Data Object", color: "#DAE8FC", icon: "🗄" },
+
+  // Technology layer
+  { name: "Node", color: "#E2F1D6", icon: "🖥" },
+  { name: "Device", color: "#E2F1D6", icon: "📱" },
+  { name: "System Software", color: "#E2F1D6", icon: "💽" },
+  { name: "Technology Collaboration", color: "#E2F1D6", icon: "🤝" },
+  { name: "Technology Interface", color: "#E2F1D6", icon: "🔌" },
+  { name: "Path", color: "#E2F1D6", icon: "🛣" },
+  { name: "Communication Network", color: "#E2F1D6", icon: "📡" },
+  { name: "Technology Function", color: "#E2F1D6", icon: "⚙" },
+  { name: "Technology Process", color: "#E2F1D6", icon: "📝" },
+  { name: "Technology Interaction", color: "#E2F1D6", icon: "🔀" },
+  { name: "Technology Service", color: "#E2F1D6", icon: "🖥" },
+  { name: "Technology Event", color: "#E2F1D6", icon: "📅" },
+  { name: "Artifact", color: "#E2F1D6", icon: "📦" },
+
+  // Motivation
+  { name: "Stakeholder", color: "#F8CECC", icon: "🙋" },
+  { name: "Driver", color: "#F8CECC", icon: "🚗" },
+  { name: "Assessment", color: "#F8CECC", icon: "📝" },
+  { name: "Goal", color: "#F8CECC", icon: "🎯" },
+  { name: "Outcome", color: "#F8CECC", icon: "🏁" },
+  { name: "Principle", color: "#F8CECC", icon: "📜" },
+  { name: "Requirement", color: "#F8CECC", icon: "✅" },
+  { name: "Constraint", color: "#F8CECC", icon: "⛔" },
+  { name: "Value", color: "#F8CECC", icon: "💎" },
+  { name: "Meaning", color: "#F8CECC", icon: "💬" },
+
+  // Implementation & Migration
+  { name: "Work Package", color: "#FDE9D9", icon: "📦" },
+  { name: "Deliverable", color: "#FDE9D9", icon: "🎁" },
+  { name: "Plateau", color: "#FDE9D9", icon: "🗺" },
+  { name: "Gap", color: "#FDE9D9", icon: "🕳" },
+  { name: "Implementation Event", color: "#FDE9D9", icon: "📅" },
+
+  // Physical
+  { name: "Facility", color: "#E6D5C3", icon: "🏢" },
+  { name: "Equipment", color: "#E6D5C3", icon: "🔧" },
+  { name: "Distribution Network", color: "#E6D5C3", icon: "🌐" },
+  { name: "Material", color: "#E6D5C3", icon: "📦" },
+
+  // Generic
+  { name: "Grouping", color: "#FFFFFF", icon: "🗂" },
+  { name: "Location", color: "#FFFFFF", icon: "📍" }
+];


### PR DESCRIPTION
## Summary
- provide a list of Archimate elements and icons
- replace old "add element" flow with palette on the right side
- allow dragging palette items to the canvas to create nodes
- nodes show icon and label with colour from Archimate layer

## Testing
- `npm run build` *(fails: next not found)*